### PR TITLE
Rackspace header specific support for file pattern uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,43 @@ grunt.initConfig({
 });
 ```
 
+##### Updating headers (Rackspace)
+
+```js
+grunt.initConfig({
+  pkgcloud: {
+    options: {
+      client: {
+        provider: 'rackspace',
+        username: 'username',
+        apiKey: 'awesomeAPIKey',
+        region: 'IAD'
+      }
+    },
+    files: [{
+      cwd: 'dist/css',
+      src: '**',
+      dest: 'test/css'
+    },{
+      cwd: 'dist/fonts',
+      src: '**',
+      dest: 'test/fonts',
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    },{
+      cwd: 'dist/image',
+      src: '**',
+      dest: 'test/image'
+    },{
+      cwd: 'dist/js',
+      src: '**',
+      dest: 'test/js'
+    }]
+  }
+});
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/pkgcloud.js
+++ b/tasks/pkgcloud.js
@@ -78,6 +78,10 @@ module.exports = function(grunt) {
             metadata: options.metadata
           };
 
+      if (path.hasOwnProperty('headers')) {
+        file.headers = path.headers;
+      }
+
       function onFileUploaded(err, result) {
         if (err || !result) {
           deferred.reject(err);
@@ -93,10 +97,16 @@ module.exports = function(grunt) {
 
     var queue = this.files.map(function(f) {
       var files = f.src.map(function(local) {
-        return {
+        var file = {
           remote: local,
           local: f.cwd + '/' + local
         };
+
+        if (f.hasOwnProperty('headers')) {
+          file.headers = f.headers;
+        }
+
+        return file;
       });
 
       return getContainer(f.dest, options.createContainer)


### PR DESCRIPTION
Utilizing this task to manage headers, for Rackspace specifically, wasn't functional.

For example, uploading fonts with this task initiated a CORS violation when the font assets are pulled into the website when loaded through Rackspace.

This PR gives Rackspace users the ability to define headers on file specific patterns.